### PR TITLE
UdfpsAnimation: Use UDFPS props verification before checking service

### DIFF
--- a/src/com/android/customization/model/udfps/UdfpsAnimationSectionController.kt
+++ b/src/com/android/customization/model/udfps/UdfpsAnimationSectionController.kt
@@ -52,16 +52,21 @@ class UdfpsAnimationSectionController(
     }
 
     private fun isUdfpsAvailable(context: Context): Boolean {
-        val hasFingerprint = context.packageManager
-                .hasSystemFeature(PackageManager.FEATURE_FINGERPRINT)
-        return if (hasFingerprint) {
-            val fingerprintManger =
-                    context.getSystemService(Context.FINGERPRINT_SERVICE) as FingerprintManager
+        return if (context.resources
+                .getIntArray(com.android.internal.R.array.config_udfps_sensor_props).isNotEmpty())
+            true
+        else {
+            val hasFingerprint = context.packageManager
+                            .hasSystemFeature(PackageManager.FEATURE_FINGERPRINT)
+            if (hasFingerprint) {
+            val fingerprintManager =
+                context.getSystemService(Context.FINGERPRINT_SERVICE) as FingerprintManager
             val udfpsProps =
-                    fingerprintManger.getSensorPropertiesInternal().map { it.isAnyUdfpsType() }
+                fingerprintManager.getSensorPropertiesInternal().map { it.isAnyUdfpsType() }
             udfpsProps.isNotEmpty() // return
-        } else {
-            false
+            } else {
+                false    
+            }
         }
     }
 


### PR DESCRIPTION
Apparently, using getSensorPropertiesInternal here even if you grant TEST_BIOMETRICS permissions results in a crash in some devices.
Let's use the previous udfps check first and move onto the new one for incompatible devices.